### PR TITLE
🐛 fix: Resolve MCP tool descriptions showing as empty

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,6 @@ dotenv.config(); // Load environment variables from .env first
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { z } from 'zod';
 import { allTools, toolHandlers } from './tools/index.js';
 
 // Create IntelliCommerce✨ Woo MCP server instance
@@ -19,10 +18,7 @@ const server = new McpServer(
   },
   {
     capabilities: {
-      tools: allTools.reduce((acc, tool) => {
-        acc[tool.name] = tool;
-        return acc;
-      }, {} as Record<string, any>),
+      tools: {},
     },
   }
 );
@@ -46,9 +42,13 @@ for (const tool of allTools) {
     };
   };
 
-  // Create a schema that allows any properties - validation is handled by the tool handlers
-  const schema = z.object({}).catchall(z.unknown());
-  server.tool(tool.name, schema.shape, wrappedHandler);
+  // Register tool with proper description and input schema
+  server.tool(
+    tool.name,
+    tool.description || 'No description available',
+    tool.inputSchema,
+    wrappedHandler
+  );
 }
 
 async function main() {
@@ -104,14 +104,14 @@ process.on('SIGINT', () => {
   );
   process.exit(0);
 });
-process.on('uncaughtException', (error) => {
+process.on('uncaughtException', error => {
   console.error(
     '❌ Uncaught exception in ✨IntelliCommerce✨ Woo MCP Server:',
     error
   );
   process.exit(1);
 });
-process.on('unhandledRejection', (error) => {
+process.on('unhandledRejection', error => {
   console.error(
     '❌ Unhandled rejection in ✨IntelliCommerce✨ Woo MCP Server:',
     error

--- a/src/tools/products.ts
+++ b/src/tools/products.ts
@@ -1,121 +1,290 @@
 // src/tools/products.ts
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
-import { makeWooCommerceRequest } from '../woocommerce.js';
-import { WooCommerceProduct } from '../types/woocommerce-types.js';
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
+import { WooCommerceProduct } from '../types/woocommerce-types.js';
+import { makeWooCommerceRequest } from '../woocommerce.js';
 
 const listProductsSchema = z.object({
-    page: z.number().optional().describe("Page number (default 1)"),
-    per_page: z.number().min(1).max(100).optional().describe("Items per page (default 10, max 100)"),
-    search: z.string().optional().describe("Search term for product name or SKU"),
-    after: z.string().optional().describe("Limit response to products published after a given ISO8601 date"),
-    before: z.string().optional().describe("Limit response to products published before a given ISO8601 date"),
-    exclude: z.array(z.number()).optional().describe("Exclude specific product IDs from the result"),
-    include: z.array(z.number()).optional().describe("Limit result set to specific product IDs"),
-    offset: z.number().optional().describe("Offset the result set by a specific number of items"),
-    featured: z.boolean().optional().describe("Limit result set to featured products"),
-    category: z.string().optional().describe("Limit result set to products assigned a specific category ID"),
-    tag: z.string().optional().describe("Limit result set to products assigned a specific tag ID"),
-    status: z.enum(['draft', 'pending', 'private', 'publish']).optional()
-        .describe("Limit result set to products assigned a specific status"),
-    type: z.enum(['simple', 'grouped', 'external', 'variable']).optional()
-        .describe("Limit result set to products assigned a specific type"),
-    sku: z.string().optional().describe("Limit result set to products with a specific SKU"),
-    orderby: z.enum(['date', 'id', 'include', 'title', 'slug', 'price', 'popularity', 'rating'])
-        .optional().describe("Sort products by parameter"),
-    order: z.enum(['asc', 'desc']).optional().describe("Order sort attribute ascending or descending"),
-    on_sale: z.boolean().optional().describe("Limit result set to products on sale"),
-    min_price: z.string().optional().describe("Limit result set to products based on a minimum price"),
-    max_price: z.string().optional().describe("Limit result set to products based on a maximum price"),
-    stock_status: z.enum(['instock', 'outofstock', 'onbackorder']).optional().describe("Limit result set to products with specified stock status")
+  page: z.number().optional().describe('Page number (default 1)'),
+  per_page: z
+    .number()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe('Items per page (default 10, max 100)'),
+  search: z.string().optional().describe('Search term for product name or SKU'),
+  after: z
+    .string()
+    .optional()
+    .describe(
+      'Limit response to products published after a given ISO8601 date'
+    ),
+  before: z
+    .string()
+    .optional()
+    .describe(
+      'Limit response to products published before a given ISO8601 date'
+    ),
+  exclude: z
+    .array(z.number())
+    .optional()
+    .describe('Exclude specific product IDs from the result'),
+  include: z
+    .array(z.number())
+    .optional()
+    .describe('Limit result set to specific product IDs'),
+  offset: z
+    .number()
+    .optional()
+    .describe('Offset the result set by a specific number of items'),
+  featured: z
+    .boolean()
+    .optional()
+    .describe('Limit result set to featured products'),
+  category: z
+    .string()
+    .optional()
+    .describe('Limit result set to products assigned a specific category ID'),
+  tag: z
+    .string()
+    .optional()
+    .describe('Limit result set to products assigned a specific tag ID'),
+  status: z
+    .enum(['draft', 'pending', 'private', 'publish'])
+    .optional()
+    .describe('Limit result set to products assigned a specific status'),
+  type: z
+    .enum(['simple', 'grouped', 'external', 'variable'])
+    .optional()
+    .describe('Limit result set to products assigned a specific type'),
+  sku: z
+    .string()
+    .optional()
+    .describe('Limit result set to products with a specific SKU'),
+  orderby: z
+    .enum([
+      'date',
+      'id',
+      'include',
+      'title',
+      'slug',
+      'price',
+      'popularity',
+      'rating',
+    ])
+    .optional()
+    .describe('Sort products by parameter'),
+  order: z
+    .enum(['asc', 'desc'])
+    .optional()
+    .describe('Order sort attribute ascending or descending'),
+  on_sale: z
+    .boolean()
+    .optional()
+    .describe('Limit result set to products on sale'),
+  min_price: z
+    .string()
+    .optional()
+    .describe('Limit result set to products based on a minimum price'),
+  max_price: z
+    .string()
+    .optional()
+    .describe('Limit result set to products based on a maximum price'),
+  stock_status: z
+    .enum(['instock', 'outofstock', 'onbackorder'])
+    .optional()
+    .describe('Limit result set to products with specified stock status'),
 });
 
 const createProductSchema = z.object({
-    name: z.string().describe("Product name"),
-    type: z.enum(['simple', 'grouped', 'external', 'variable']).optional().describe("Product type"),
-    status: z.enum(['draft', 'pending', 'private', 'publish']).optional().describe("Product status"),
-    featured: z.boolean().optional().describe("Featured product"),
-    catalog_visibility: z.enum(['visible', 'catalog', 'search', 'hidden']).optional().describe("Catalog visibility"),
-    description: z.string().optional().describe("Product description"),
-    short_description: z.string().optional().describe("Product short description"),
-    sku: z.string().optional().describe("Unique identifier"),
-    regular_price: z.string().optional().describe("Product regular price"),
-    sale_price: z.string().optional().describe("Product sale price"),
-    date_on_sale_from: z.string().optional().describe("Start date of sale price, in the site's timezone"),
-    date_on_sale_to: z.string().optional().describe("End date of sale price, in the site's timezone"),
-    virtual: z.boolean().optional().describe("If the product is virtual"),
-    downloadable: z.boolean().optional().describe("If the product is downloadable"),
-    downloads: z.array(z.object({
+  name: z.string().describe('Product name'),
+  type: z
+    .enum(['simple', 'grouped', 'external', 'variable'])
+    .optional()
+    .describe('Product type'),
+  status: z
+    .enum(['draft', 'pending', 'private', 'publish'])
+    .optional()
+    .describe('Product status'),
+  featured: z.boolean().optional().describe('Featured product'),
+  catalog_visibility: z
+    .enum(['visible', 'catalog', 'search', 'hidden'])
+    .optional()
+    .describe('Catalog visibility'),
+  description: z.string().optional().describe('Product description'),
+  short_description: z
+    .string()
+    .optional()
+    .describe('Product short description'),
+  sku: z.string().optional().describe('Unique identifier'),
+  regular_price: z.string().optional().describe('Product regular price'),
+  sale_price: z.string().optional().describe('Product sale price'),
+  date_on_sale_from: z
+    .string()
+    .optional()
+    .describe("Start date of sale price, in the site's timezone"),
+  date_on_sale_to: z
+    .string()
+    .optional()
+    .describe("End date of sale price, in the site's timezone"),
+  virtual: z.boolean().optional().describe('If the product is virtual'),
+  downloadable: z
+    .boolean()
+    .optional()
+    .describe('If the product is downloadable'),
+  downloads: z
+    .array(
+      z.object({
         id: z.string().optional(),
         name: z.string(),
-        file: z.string()
-    })).optional().describe("List of downloadable files"),
-    download_limit: z.number().optional().describe("Number of times downloadable files can be downloaded after purchase"),
-    download_expiry: z.number().optional().describe("Number of days until download link expires"),
-    external_url: z.string().optional().describe("Product external URL. Only for external products"),
-    button_text: z.string().optional().describe("Product external button text. Only for external products"),
-    tax_status: z.enum(['taxable', 'shipping', 'none']).optional().describe("Tax status"),
-    tax_class: z.string().optional().describe("Tax class"),
-    manage_stock: z.boolean().optional().describe("Stock management at product level"),
-    stock_quantity: z.number().optional().describe("Stock quantity"),
-    stock_status: z.enum(['instock', 'outofstock', 'onbackorder']).optional().describe("Controls the stock status of the product"),
-    backorders: z.enum(['no', 'notify', 'yes']).optional().describe("If managing stock, this controls if backorders are allowed"),
-    sold_individually: z.boolean().optional().describe("Allow one item to be bought in a single order"),
-    weight: z.string().optional().describe("Product weight"),
-    dimensions: z.object({
-        length: z.string(),
-        width: z.string(),
-        height: z.string()
-    }).optional().describe("Product dimensions"),
-    shipping_class: z.string().optional().describe("Shipping class slug"),
-    reviews_allowed: z.boolean().optional().describe("Allow reviews"),
-    upsell_ids: z.array(z.number()).optional().describe("List of up-sell products IDs"),
-    cross_sell_ids: z.array(z.number()).optional().describe("List of cross-sell products IDs"),
-    parent_id: z.number().optional().describe("Product parent ID"),
-    purchase_note: z.string().optional().describe("Optional note to send the customer after purchase"),
-    categories: z.array(z.object({
+        file: z.string(),
+      })
+    )
+    .optional()
+    .describe('List of downloadable files'),
+  download_limit: z
+    .number()
+    .optional()
+    .describe(
+      'Number of times downloadable files can be downloaded after purchase'
+    ),
+  download_expiry: z
+    .number()
+    .optional()
+    .describe('Number of days until download link expires'),
+  external_url: z
+    .string()
+    .optional()
+    .describe('Product external URL. Only for external products'),
+  button_text: z
+    .string()
+    .optional()
+    .describe('Product external button text. Only for external products'),
+  tax_status: z
+    .enum(['taxable', 'shipping', 'none'])
+    .optional()
+    .describe('Tax status'),
+  tax_class: z.string().optional().describe('Tax class'),
+  manage_stock: z
+    .boolean()
+    .optional()
+    .describe('Stock management at product level'),
+  stock_quantity: z.number().optional().describe('Stock quantity'),
+  stock_status: z
+    .enum(['instock', 'outofstock', 'onbackorder'])
+    .optional()
+    .describe('Controls the stock status of the product'),
+  backorders: z
+    .enum(['no', 'notify', 'yes'])
+    .optional()
+    .describe('If managing stock, this controls if backorders are allowed'),
+  sold_individually: z
+    .boolean()
+    .optional()
+    .describe('Allow one item to be bought in a single order'),
+  weight: z.string().optional().describe('Product weight'),
+  dimensions: z
+    .object({
+      length: z.string(),
+      width: z.string(),
+      height: z.string(),
+    })
+    .optional()
+    .describe('Product dimensions'),
+  shipping_class: z.string().optional().describe('Shipping class slug'),
+  reviews_allowed: z.boolean().optional().describe('Allow reviews'),
+  upsell_ids: z
+    .array(z.number())
+    .optional()
+    .describe('List of up-sell products IDs'),
+  cross_sell_ids: z
+    .array(z.number())
+    .optional()
+    .describe('List of cross-sell products IDs'),
+  parent_id: z.number().optional().describe('Product parent ID'),
+  purchase_note: z
+    .string()
+    .optional()
+    .describe('Optional note to send the customer after purchase'),
+  categories: z
+    .array(
+      z.object({
         id: z.number().optional(),
         name: z.string().optional(),
-        slug: z.string().optional()
-    })).optional().describe("List of categories"),
-    tags: z.array(z.object({
+        slug: z.string().optional(),
+      })
+    )
+    .optional()
+    .describe('List of categories'),
+  tags: z
+    .array(
+      z.object({
         id: z.number().optional(),
         name: z.string().optional(),
-        slug: z.string().optional()
-    })).optional().describe("List of tags"),
-    attributes: z.array(z.object({
+        slug: z.string().optional(),
+      })
+    )
+    .optional()
+    .describe('List of tags'),
+  attributes: z
+    .array(
+      z.object({
         id: z.number().optional(),
         name: z.string(),
         position: z.number().optional(),
         visible: z.boolean().optional(),
         variation: z.boolean().optional(),
-        options: z.array(z.string())
-    })).optional().describe("List of attributes"),
-    default_attributes: z.array(z.object({
+        options: z.array(z.string()),
+      })
+    )
+    .optional()
+    .describe('List of attributes'),
+  default_attributes: z
+    .array(
+      z.object({
         id: z.number().optional(),
         name: z.string(),
-        option: z.string()
-    })).optional().describe("Defaults variation attributes"),
-    grouped_products: z.array(z.number()).optional().describe("List of grouped products ID"),
-    menu_order: z.number().optional().describe("Menu order, used to custom sort products"),
-    meta_data: z.array(z.object({
+        option: z.string(),
+      })
+    )
+    .optional()
+    .describe('Defaults variation attributes'),
+  grouped_products: z
+    .array(z.number())
+    .optional()
+    .describe('List of grouped products ID'),
+  menu_order: z
+    .number()
+    .optional()
+    .describe('Menu order, used to custom sort products'),
+  meta_data: z
+    .array(
+      z.object({
         key: z.string(),
-        value: z.string()
-    })).optional().describe("Meta data")
+        value: z.string(),
+      })
+    )
+    .optional()
+    .describe('Meta data'),
 });
 
 const getProductSchema = z.object({
-    id: z.number().describe("Product ID")
+  id: z.number().describe('Product ID'),
 });
 
-const updateProductSchema = createProductSchema.extend({
-    id: z.number().describe("Product ID")
-}).partial();
+const updateProductSchema = createProductSchema
+  .extend({
+    id: z.number().describe('Product ID'),
+  })
+  .partial();
 
 const deleteProductSchema = z.object({
-    id: z.number().describe("Product ID"),
-    force: z.boolean().optional().describe("Required to be true, as resource does not support trashing")
+  id: z.number().describe('Product ID'),
+  force: z
+    .boolean()
+    .optional()
+    .describe('Required to be true, as resource does not support trashing'),
 });
 
 type ListProductsParams = z.infer<typeof listProductsSchema>;
@@ -125,128 +294,169 @@ type UpdateProductParams = z.infer<typeof updateProductSchema>;
 type DeleteProductParams = z.infer<typeof deleteProductSchema>;
 
 export const productTools: Tool[] = [
-    {
-        name: "list_products",
-        description: "Lists all products with filtering, sorting, and pagination options",
-        inputSchema: zodToJsonSchema(listProductsSchema) as { type: "object"; properties: Record<string, unknown> }
+  {
+    name: 'list_products',
+    description:
+      'Lists WooCommerce products with advanced filtering by category, tag, price range, stock status, and comprehensive sorting/pagination options',
+    inputSchema: zodToJsonSchema(listProductsSchema) as {
+      type: 'object';
+      properties: Record<string, unknown>;
     },
-    {
-        name: "create_product",
-        description: "Creates a new product",
-        inputSchema: zodToJsonSchema(createProductSchema) as { type: "object"; properties: Record<string, unknown> }
+  },
+  {
+    name: 'create_product',
+    description:
+      'Creates a new WooCommerce product with full support for simple, variable, grouped, and external product types',
+    inputSchema: zodToJsonSchema(createProductSchema) as {
+      type: 'object';
+      properties: Record<string, unknown>;
     },
-    {
-        name: "get_product",
-        description: "Gets a product by ID",
-        inputSchema: zodToJsonSchema(getProductSchema) as { type: "object"; properties: Record<string, unknown> }
+  },
+  {
+    name: 'get_product',
+    description:
+      'Retrieves a specific WooCommerce product by ID with complete product details and metadata',
+    inputSchema: zodToJsonSchema(getProductSchema) as {
+      type: 'object';
+      properties: Record<string, unknown>;
     },
-    {
-        name: "update_product",
-        description: "Updates an existing product",
-        inputSchema: zodToJsonSchema(updateProductSchema) as { type: "object"; properties: Record<string, unknown> }
+  },
+  {
+    name: 'update_product',
+    description:
+      'Updates an existing WooCommerce product with partial data support (only specified fields are modified)',
+    inputSchema: zodToJsonSchema(updateProductSchema) as {
+      type: 'object';
+      properties: Record<string, unknown>;
     },
-    {
-        name: "delete_product",
-        description: "Deletes a product",
-        inputSchema: zodToJsonSchema(deleteProductSchema) as { type: "object"; properties: Record<string, unknown> }
-    }
+  },
+  {
+    name: 'delete_product',
+    description:
+      'Permanently deletes a WooCommerce product (bypass trash, requires force=true)',
+    inputSchema: zodToJsonSchema(deleteProductSchema) as {
+      type: 'object';
+      properties: Record<string, unknown>;
+    },
+  },
 ];
 
 export const productHandlers = {
-    list_products: async (params: ListProductsParams) => {
-        try {
-            const response = await makeWooCommerceRequest('GET', "products", params);
-            const products: WooCommerceProduct[] = response;
-            return {
-                toolResult: {
-                    content: [{ type: 'text', text: JSON.stringify(products, null, 2) }],
-                },
-            };
-        } catch (error: any) {
-            const errorMessage = error.response?.data?.message || error.message;
-            return {
-                toolResult: {
-                    isError: true,
-                    content: [{ type: 'text', text: `Error listing products: ${errorMessage}` }],
-                },
-            };
-        }
-    },
-    create_product: async (params: CreateProductParams) => {
-        try {
-            const response = await makeWooCommerceRequest('POST', "products", params);
-            const product: WooCommerceProduct = response;
-            return {
-                toolResult: {
-                    content: [{ type: 'text', text: JSON.stringify(product, null, 2) }],
-                },
-            };
-        } catch (error: any) {
-            const errorMessage = error.response?.data?.message || error.message;
-            return {
-                toolResult: {
-                    isError: true,
-                    content: [{ type: 'text', text: `Error creating product: ${errorMessage}` }],
-                },
-            };
-        }
-    },
-    get_product: async (params: GetProductParams) => {
-        try {
-            const response = await makeWooCommerceRequest('GET', `products/${params.id}`);
-            const product: WooCommerceProduct = response;
-            return {
-                toolResult: {
-                    content: [{ type: 'text', text: JSON.stringify(product, null, 2) }],
-                },
-            };
-        } catch (error: any) {
-            const errorMessage = error.response?.data?.message || error.message;
-            return {
-                toolResult: {
-                    isError: true,
-                    content: [{ type: 'text', text: `Error getting product: ${errorMessage}` }],
-                },
-            };
-        }
-    },
-    update_product: async (params: UpdateProductParams) => {
-        try {
-            const { id, ...updateData } = params;
-            const response = await makeWooCommerceRequest('PUT', `products/${id}`, updateData);
-            const product: WooCommerceProduct = response;
-            return {
-                toolResult: {
-                    content: [{ type: 'text', text: JSON.stringify(product, null, 2) }],
-                },
-            };
-        } catch (error: any) {
-            const errorMessage = error.response?.data?.message || error.message;
-            return {
-                toolResult: {
-                    isError: true,
-                    content: [{ type: 'text', text: `Error updating product: ${errorMessage}` }],
-                },
-            };
-        }
-    },
-    delete_product: async (params: DeleteProductParams) => {
-        try {
-            const response = await makeWooCommerceRequest('DELETE', `products/${params.id}`, { force: params.force });
-            const product: WooCommerceProduct = response;
-            return {
-                toolResult: {
-                    content: [{ type: 'text', text: JSON.stringify(product, null, 2) }],
-                },
-            };
-        } catch (error: any) {
-            const errorMessage = error.response?.data?.message || error.message;
-            return {
-                toolResult: {
-                    isError: true,
-                    content: [{ type: 'text', text: `Error deleting product: ${errorMessage}` }],
-                },
-            };
-        }
+  list_products: async (params: ListProductsParams) => {
+    try {
+      const response = await makeWooCommerceRequest('GET', 'products', params);
+      const products: WooCommerceProduct[] = response;
+      return {
+        toolResult: {
+          content: [{ type: 'text', text: JSON.stringify(products, null, 2) }],
+        },
+      };
+    } catch (error: any) {
+      const errorMessage = error.response?.data?.message || error.message;
+      return {
+        toolResult: {
+          isError: true,
+          content: [
+            { type: 'text', text: `Error listing products: ${errorMessage}` },
+          ],
+        },
+      };
     }
+  },
+  create_product: async (params: CreateProductParams) => {
+    try {
+      const response = await makeWooCommerceRequest('POST', 'products', params);
+      const product: WooCommerceProduct = response;
+      return {
+        toolResult: {
+          content: [{ type: 'text', text: JSON.stringify(product, null, 2) }],
+        },
+      };
+    } catch (error: any) {
+      const errorMessage = error.response?.data?.message || error.message;
+      return {
+        toolResult: {
+          isError: true,
+          content: [
+            { type: 'text', text: `Error creating product: ${errorMessage}` },
+          ],
+        },
+      };
+    }
+  },
+  get_product: async (params: GetProductParams) => {
+    try {
+      const response = await makeWooCommerceRequest(
+        'GET',
+        `products/${params.id}`
+      );
+      const product: WooCommerceProduct = response;
+      return {
+        toolResult: {
+          content: [{ type: 'text', text: JSON.stringify(product, null, 2) }],
+        },
+      };
+    } catch (error: any) {
+      const errorMessage = error.response?.data?.message || error.message;
+      return {
+        toolResult: {
+          isError: true,
+          content: [
+            { type: 'text', text: `Error getting product: ${errorMessage}` },
+          ],
+        },
+      };
+    }
+  },
+  update_product: async (params: UpdateProductParams) => {
+    try {
+      const { id, ...updateData } = params;
+      const response = await makeWooCommerceRequest(
+        'PUT',
+        `products/${id}`,
+        updateData
+      );
+      const product: WooCommerceProduct = response;
+      return {
+        toolResult: {
+          content: [{ type: 'text', text: JSON.stringify(product, null, 2) }],
+        },
+      };
+    } catch (error: any) {
+      const errorMessage = error.response?.data?.message || error.message;
+      return {
+        toolResult: {
+          isError: true,
+          content: [
+            { type: 'text', text: `Error updating product: ${errorMessage}` },
+          ],
+        },
+      };
+    }
+  },
+  delete_product: async (params: DeleteProductParams) => {
+    try {
+      const response = await makeWooCommerceRequest(
+        'DELETE',
+        `products/${params.id}`,
+        { force: params.force }
+      );
+      const product: WooCommerceProduct = response;
+      return {
+        toolResult: {
+          content: [{ type: 'text', text: JSON.stringify(product, null, 2) }],
+        },
+      };
+    } catch (error: any) {
+      const errorMessage = error.response?.data?.message || error.message;
+      return {
+        toolResult: {
+          isError: true,
+          content: [
+            { type: 'text', text: `Error deleting product: ${errorMessage}` },
+          ],
+        },
+      };
+    }
+  },
 };


### PR DESCRIPTION
## 🎯 Problem Solved

MCP clients (VS Code Copilot, Claude Desktop) were showing tool descriptions as `<empty>` instead of the actual tool descriptions. This significantly impacted user experience when browsing available WooCommerce tools.

## 🔧 Changes Made

### Core Fix
- **Fixed MCP server tool registration** to properly pass descriptions to MCP clients
- Updated `server.tool()` calls to include description parameter as required by MCP SDK
- Removed redundant tool definitions from server capabilities

### Code Quality Improvements  
- Enhanced product tool descriptions for better clarity and user experience
- Removed unused `zod` import for cleaner code
- Improved code formatting and import organization

## ✅ Validation

- ✅ All pre-commit hooks passed (lint, typecheck, tests, build)
- ✅ Tool descriptions now display properly in MCP clients
- ✅ No breaking changes or API modifications
- ✅ Backwards compatible with existing configurations

## 🚀 Testing

Tested with:
- VS Code Copilot agent mode ✅
- Global installation via `intellicommerce-woo-mcp` ✅  
- Project-level MCP configuration ✅
- User-level MCP configuration ✅

## 🌟 Upstream Contribution Ready

This fix benefits the entire WooCommerce MCP ecosystem and is ready for contribution to the upstream Automattic repository.

**Made with 🧡 in Cape Town 🇿🇦**
**Powered by Xstra AI✨ | Enabled by IntelliCommerce✨**