### PR TITLE
🐛 Fix: Add missing build step to CI release job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -161,6 +161,9 @@ jobs:
     - name: 📦 Install dependencies
       run: npm ci
 
+    - name: 🏗️ Build project
+      run: npm run build
+
     - name: 🔧 Configure Git
       run: |
         git config user.name "IntelliCommerce✨ Bot"


### PR DESCRIPTION
## 🚨 Critical CI/CD Fix

This PR resolves the GitHub Actions integration test failures in the release job.

### 🔍 Root Cause Analysis
The **release job** was failing because:
1. Integration tests expect `build/server.js` to exist
2. Release job runs `standard-version` which triggers tests
3. **Missing build step** meant no build artifacts existed
4. Integration test: `expect(fs.existsSync(serverPath)).toBe(true)` → **FAILED**

### ✅ Solution Implemented
Added `🏗️ Build project` step to release job **before** the release process:

```yaml
- name: 🏗️ Build project
  run: npm run build
```

### 🧪 Validation
- ✅ **Locally tested**: Integration tests pass with build files
- ✅ **Locally tested**: Integration tests fail without build files  
- ✅ **Pre-commit passed**: All checks successful
- ✅ **Workflow order**: Build → Configure Git → Release

### 📋 Changes Made
- `.github/workflows/ci-cd.yml`: Added build step before release process
- **Zero breaking changes** - only adds missing step
- **Maintains workflow security** - husky bypass still in place

### 🎯 Expected Result
- ✅ Integration tests will pass in release job
- ✅ Release automation will complete successfully  
- ✅ Automated npm publishing will work
- ✅ Build artifacts available for packaging

**Made with 🧡 in Cape Town 🇿🇦**  
**Powered by Xstra AI✨ | Enabled by IntelliCommerce✨**