### PR TITLE
🔧 fix: Make husky CI-friendly to prevent release workflow failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint": "^9.28.0",
         "eslint-config-prettier": "^10.1.5",
         "husky": "^9.1.7",
+        "is-ci": "^4.1.0",
         "jest": "^29.7.0",
         "lint-staged": "^16.1.0",
         "prettier": "^3.5.3",
@@ -40,6 +41,10 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jlfguthrie"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3497,6 +3502,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/ci-info": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
+      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
@@ -6029,6 +6050,25 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-ci": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-4.1.0.tgz",
+      "integrity": "sha512-Ab9bQDQ11lWootZUI5qxgN2ZXwxNI5hTwnsvOc1wyxQ7zQ8OkEDw79mI0+9jI3x432NfwbVRru+3noJfXF6lSQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^4.1.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "publish:test": "npm run build && npm pack && echo \"Package created successfully for testing\"",
     "husky:install": "husky install",
     "prestart": "npm run build",
-    "prepare": "husky",
+    "prepare": "is-ci || husky install",
     "global:install": "npm run build && npm install -g .",
     "global:uninstall": "npm uninstall -g intellicommerce-woo-mcp",
     "global:test": "intellicommerce-woo-mcp --help"
@@ -138,6 +138,7 @@
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.5",
     "husky": "^9.1.7",
+    "is-ci": "^4.1.0",
     "jest": "^29.7.0",
     "lint-staged": "^16.1.0",
     "prettier": "^3.5.3",


### PR DESCRIPTION
## 🎯 Problem Fixed

Release workflows were failing during `npm ci` because the `prepare` script was trying to run `husky` in CI environments where it's not available.

**Error:**
```
sh: 1: husky: not found
npm error code 127
```

## 🔧 Solution

- **Added `is-ci` package** to detect CI environments
- **Updated prepare script** to `is-ci || husky install`
- **CI-friendly approach** that skips husky setup in automated environments

## 📋 What This Fixes

- ✅ **Release workflows** will no longer fail during dependency installation
- ✅ **NPM publishing** can proceed without husky conflicts
- ✅ **Local development** still has full husky functionality  
- ✅ **CI environments** gracefully skip husky setup

## 🧪 Testing

- ✅ Pre-commit hooks passed locally
- ✅ TypeScript compilation successful
- ✅ All tests passing

This fix is critical for the release workflow to complete successfully and publish to NPM.

---
**Made with 🧡 in Cape Town 🇿🇦**