### PR TITLE
🔧 fix: Use Node.js built-in CI detection for husky prepare script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "eslint": "^9.28.0",
         "eslint-config-prettier": "^10.1.5",
         "husky": "^9.1.7",
-        "is-ci": "^4.1.0",
         "jest": "^29.7.0",
         "lint-staged": "^16.1.0",
         "prettier": "^3.5.3",
@@ -3502,22 +3501,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/ci-info": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
@@ -6050,25 +6033,6 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-ci": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-4.1.0.tgz",
-      "integrity": "sha512-Ab9bQDQ11lWootZUI5qxgN2ZXwxNI5hTwnsvOc1wyxQ7zQ8OkEDw79mI0+9jI3x432NfwbVRru+3noJfXF6lSQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^4.1.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
-      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "publish:test": "npm run build && npm pack && echo \"Package created successfully for testing\"",
     "husky:install": "husky install",
     "prestart": "npm run build",
-    "prepare": "is-ci || husky install",
+    "prepare": "node -e \"process.exit(process.env.CI ? 0 : 1)\" || npx husky install",
     "global:install": "npm run build && npm install -g .",
     "global:uninstall": "npm uninstall -g intellicommerce-woo-mcp",
     "global:test": "intellicommerce-woo-mcp --help"
@@ -138,7 +138,6 @@
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.5",
     "husky": "^9.1.7",
-    "is-ci": "^4.1.0",
     "jest": "^29.7.0",
     "lint-staged": "^16.1.0",
     "prettier": "^3.5.3",


### PR DESCRIPTION
## 🎯 Problem Solved

The previous CI detection method using `is-ci` package was failing during `npm ci` because:
- The prepare script runs **during** the npm install process
- Dependencies (including `is-ci`) aren't available yet during prepare
- This caused `command not found` errors in CI environments

## ✅ Solution

Replaced external dependency with Node.js built-in CI detection:
- Use `process.env.CI` check directly (set by most CI platforms)
- Use `npx husky install` to ensure husky is available during prepare
- Remove `is-ci` dependency to reduce package size

## �� Testing

- ✅ Works in CI environments (`CI=true`)
- ✅ Works in local development (no CI env var)
- ✅ Reduces dependencies and complexity
- ✅ All pre-commit validations pass

## 📋 Changes

- **package.json**: Updated prepare script to use native CI detection
- **package-lock.json**: Removed `is-ci` dependency
- **CI-friendly**: No longer fails during `npm ci` in GitHub Actions

## 🔄 Next Steps

After merge, this will enable successful release workflow runs that publish to npm.

---
**Made with 🧡 in Cape Town 🇿🇦**
**Powered by Xstra AI✨ | Enabled by IntelliCommerce✨**