### PR TITLE
🔒 fix: Resolve security script false positive on .env detection

### DIFF
--- a/scripts/security-check.sh
+++ b/scripts/security-check.sh
@@ -61,12 +61,15 @@ fi
 # Verify npmignore is protecting sensitive files
 echo "🔍 Validating npm package contents..."
 excluded_patterns=0
-if npm pack --dry-run 2>/dev/null | grep -E "(\.env)" >/dev/null; then
+
+# Check for .env files in tarball contents (not in prepare script output)
+if npm pack --dry-run 2>/dev/null | grep -E "^npm notice .*(\.env)" >/dev/null; then
     echo "❌ .env files would be included in npm package!"
     ((excluded_patterns++))
 fi
 
-if npm pack --dry-run 2>/dev/null | grep -E "(docs/internal)" >/dev/null; then
+# Check for internal docs in tarball contents
+if npm pack --dry-run 2>/dev/null | grep -E "^npm notice .*(docs/internal)" >/dev/null; then
     echo "❌ Internal documentation would be included in npm package!"
     ((excluded_patterns++))
 fi


### PR DESCRIPTION
## 🎯 Problem Solved

The security validation script was incorrectly failing during release workflows with:
> ❌ .env files would be included in npm package!

**Root Cause**: The `npm pack --dry-run` command includes output from the prepare script, which now contains the text `.env` as part of our CI detection logic. The security script's grep pattern was matching this script output rather than actual file listings.

## ✅ Solution

Fixed the grep pattern to be more specific:
- **Before**: `grep -E "(\.env)"` (matched any line)
- **After**: `grep -E "^npm notice .*(\.env)"` (only matches tarball file listings)

This ensures the security check only flags actual `.env` files in the package contents, not script output that happens to contain the text ".env".

## 🧪 Testing

- ✅ Security script now passes locally
- ✅ No actual `.env` files are included in npm package (verified via npm pack)
- ✅ `.npmignore` properly excludes sensitive files
- ✅ All pre-commit validations pass

## 📋 Changes

- **scripts/security-check.sh**: Updated grep patterns to be more precise

## 🔄 Next Steps

After merge, the release workflow should complete successfully through to npm publication.

---
**Made with 🧡 in Cape Town 🇿🇦**
**Powered by Xstra AI✨ | Enabled by IntelliCommerce✨**