### PR TITLE
🔧 fix: Add Jest types to TypeScript configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
         "skipLibCheck": true,
         "outDir": "./build",
         "rootDir": "./src",
-        "declaration": true
+        "declaration": true,
+        "types": ["node", "jest"]
     },
     "include": ["src/**/*"],
     "exclude": ["node_modules", "build"]


### PR DESCRIPTION
## 🎯 Problem Solved

TypeScript compilation was failing in CI due to missing Jest type definitions:
- `beforeEach` and `afterEach` functions not recognized
- Test files couldn't compile due to missing Jest globals
- CI/CD release workflow failing at typecheck step

## ✅ Solution

Added Jest types to TypeScript configuration:
- Include `jest` in types array alongside `node`
- Enables proper TypeScript checking for test files
- Resolves all Jest-related type errors

## 🧪 Testing

- ✅ TypeScript compilation passes (`npm run typecheck`)
- ✅ Unit tests run successfully (`npm run test:unit`)
- ✅ All pre-commit validations pass
- ✅ Build completes without errors

## 📋 Changes

- **tsconfig.json**: Added `jest` to types array

## 🔄 Next Steps

After merge, this enables the CI/CD release workflow to complete successfully and publish to npm.

---
**Made with 🧡 in Cape Town 🇿🇦**
**Powered by Xstra AI✨ | Enabled by IntelliCommerce✨**