### PR TITLE
🔧 fix: Ensure devDependencies installed in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
   # This will be triggered manually or via workflow_call from CI/CD
 
 env:
-  NODE_ENV: production
+  NODE_ENV: development  # Need devDependencies for TypeScript compilation
 
 jobs:
   # Pre-flight checks - only run if needed
@@ -48,14 +48,15 @@ jobs:
 
     - name: 📦 Install dependencies
       run: |
-        # Ensure dev dependencies are installed for TypeScript compilation
-        npm ci
+        # Install all dependencies including devDependencies for TypeScript compilation
+        npm ci --include=dev
 
-        # Verify @types/node is available
+        # Verify @types/node and typescript are available
         ls -la node_modules/@types/node/ || echo "⚠️ @types/node not found"
+        ls -la node_modules/typescript/ || echo "⚠️ typescript not found"
 
         # Debug TypeScript configuration
-        echo "TypeScript version: $(npx tsc --version)"
+        echo "TypeScript version: $(npx typescript/bin/tsc --version)"
         echo "Node.js version: $(node --version)"
 
     - name: 🔒 Security validation
@@ -160,7 +161,7 @@ jobs:
         cache: 'npm'
 
     - name: 📦 Install dependencies
-      run: npm ci
+      run: npm ci --include=dev
 
     - name: 📈 Generate changelog
       run: |
@@ -265,7 +266,7 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
 
     - name: 📦 Install dependencies
-      run: npm ci
+      run: npm ci --include=dev
 
     - name: 🏗️ Build for publishing
       run: |


### PR DESCRIPTION
Fixes TypeScript compilation errors in GitHub Actions release workflow by ensuring devDependencies are properly installed.

**Root Cause:**
The release workflow was running with  which caused 
> intellicommerce-woo-mcp@1.1.12 prepare
> node -e "process.exit(process.env.CI ? 0 : 1)" || npx husky install


added 878 packages, and audited 879 packages in 3s

139 packages are looking for funding
  run `npm fund` for details

1 low severity vulnerability

To address all issues, run:
  npm audit fix

Run `npm audit` for details. to skip devDependencies. This led to missing , , and  packages during the build process.

**Changes:**
- ✅ Change  from  to  
- ✅ Update all 
> intellicommerce-woo-mcp@1.1.12 prepare
> node -e "process.exit(process.env.CI ? 0 : 1)" || npx husky install


added 878 packages, and audited 879 packages in 3s

139 packages are looking for funding
  run `npm fund` for details

1 low severity vulnerability

To address all issues, run:
  npm audit fix

Run `npm audit` for details. commands to use  flag
- ✅ Enhanced dependency verification with TypeScript and @types checks
- ✅ Fixed TypeScript compiler path from  to 

**Resolves:**
- 
- 
- Wrong TypeScript command (tsc@2.0.4) being used

Made with 🧡 in Cape Town 🇿🇦