### PR TITLE
🔧 fix: Resolve release packaging error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,9 +202,17 @@ jobs:
         # Create tarball for release
         npm pack
 
-        # Rename to include version
+        # Check if rename is needed
         VERSION="${{ needs.validate.outputs.new_version }}"
-        mv intellicommerce-woo-mcp-*.tgz "intellicommerce-woo-mcp-${VERSION#v}.tgz"
+        EXPECTED_NAME="intellicommerce-woo-mcp-${VERSION#v}.tgz"
+        ACTUAL_NAME=$(ls intellicommerce-woo-mcp-*.tgz)
+
+        if [ "$ACTUAL_NAME" != "$EXPECTED_NAME" ]; then
+          mv "$ACTUAL_NAME" "$EXPECTED_NAME"
+          echo "Renamed $ACTUAL_NAME to $EXPECTED_NAME"
+        else
+          echo "Package already has correct name: $EXPECTED_NAME"
+        fi
 
     - name: 🚀 Create GitHub Release
       id: release


### PR DESCRIPTION
Fixes the final packaging step in the release workflow.

**Root Cause:**
npm pack already creates the file with the correct version name, so trying to rename it to the same name causes a 'same file' error.

**Fix:**
- Add check to only rename if the file doesn't already have the expected name
- Prevents mv error in release workflow
- Improves robustness of packaging step

This should complete our GitHub Actions workflow fixes and allow successful releases.

Made with 🧡 in Cape Town 🇿🇦