### PR TITLE
🐛 fix: Complete npm publish workflow fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,12 @@ jobs:
           });
 
           console.log(`✅ Created release ${tagName} with ID ${release.data.id}`);
+          console.log(`📤 Upload URL: ${release.data.upload_url}`);
+
+          // Set outputs for subsequent steps
+          core.setOutput('upload_url', release.data.upload_url);
+          core.setOutput('release_id', release.data.id);
+
           return release.data.id;
 
     - name: 📎 Upload Release Asset
@@ -248,10 +254,22 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.release.outputs.upload_url }}
-        asset_path: ./intellicommerce-woo-mcp-${{ needs.validate.outputs.new_version }}.tgz
-        asset_name: intellicommerce-woo-mcp-${{ needs.validate.outputs.new_version }}.tgz
-        asset_content_type: application/gzip
+    - name: 📎 Upload Release Asset
+      run: |
+        # The file created by npm pack strips the 'v' prefix
+        VERSION="${{ needs.validate.outputs.new_version }}"
+        ASSET_FILE="intellicommerce-woo-mcp-${VERSION#v}.tgz"
+
+        # Upload the asset using curl since the action has path issues
+        curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Content-Type: application/gzip" \
+          "${{ steps.release.outputs.upload_url }}?name=${ASSET_FILE}" \
+          --data-binary "@${ASSET_FILE}"
+
+        echo "✅ Uploaded asset: ${ASSET_FILE}"
 
   # Publish to npm
   publish:
@@ -259,6 +277,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate, release]
     if: needs.validate.outputs.should_release == 'true' && needs.release.result == 'success'
+
+    env:
+      NODE_ENV: development  # Need devDependencies for TypeScript compilation
 
     steps:
     - name: 📥 Checkout code
@@ -284,16 +305,32 @@ jobs:
 
     - name: 🔐 Configure npm authentication
       run: |
-        echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+        # Debug npm authentication
+        echo "Checking NPM_TOKEN availability..."
+        if [ -n "${{ secrets.NPM_TOKEN }}" ]; then
+          echo "✅ NPM_TOKEN is available"
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+        else
+          echo "❌ NPM_TOKEN is not available"
+          exit 1
+        fi
 
     - name: 📦 Publish to npm
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: |
-        if [ -z "$NODE_AUTH_TOKEN" ]; then
+        # Debug environment
+        echo "NODE_AUTH_TOKEN available: $([ -n "$NODE_AUTH_TOKEN" ] && echo "yes" || echo "no")"
+        echo "NPM_TOKEN available: $([ -n "$NPM_TOKEN" ] && echo "yes" || echo "no")"
+
+        if [ -z "$NPM_TOKEN" ]; then
           echo "⚠️ NPM_TOKEN not available, skipping npm publish"
-          exit 0
+          exit 1
         fi
+
+        # Verify npm authentication
+        npm whoami || (echo "❌ npm authentication failed" && exit 1)
 
         # Publish to npm
         npm publish --access public


### PR DESCRIPTION
This PR fixes the remaining issues in the release workflow that were preventing npm publishing:

## 🔧 Fixes Applied

### 1. GitHub Release Upload Issue
- Fixed github-script step to properly set upload_url output using core.setOutput
- Replaced problematic upload-release-asset with direct curl upload for better path handling
- Fixed asset path to match npm pack output (strips v prefix correctly)

### 2. NPM Publishing Authentication  
- Added comprehensive NPM_TOKEN debugging and validation
- Set NODE_ENV=development for publish job to ensure devDependencies are available
- Improved error handling with proper exit codes for failed authentication
- Added npm whoami verification before publishing

### 3. Workflow Reliability
- Enhanced error messages and debugging output
- Proper environment variable handling across all jobs
- Fixed conditional logic for job dependencies

## 🧪 Expected Results
After merging this PR, the release workflow should:
- Create GitHub releases successfully  
- Upload release assets properly
- Publish to npm registry with v1.1.13+
- Complete end-to-end without failures

Made with 🧡 in Cape Town 🇿🇦